### PR TITLE
#6 Remove composer installer, to not copy app/code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
     }
   ],
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0",
-    "magento/magento-composer-installer": "*"
+    "php": "~5.5.0|~5.6.0|~7.0.0"
   },
   "type": "magento2-module",
   "version": "0.1.0",


### PR DESCRIPTION
Module should not be copied to app/code
See also the core modules
