### PR TITLE
update hints init block, get assets repository from context object

### DIFF
--- a/Block/Hints/Init.php
+++ b/Block/Hints/Init.php
@@ -34,20 +34,18 @@ class Init extends AbstractBlock
 
     /**
      * @param Context         $context
-     * @param AssetRepository $assetRepository
      * @param AssetCollection $assetCollection
      * @param Config          $config
      * @param array           $data
      */
     public function __construct(
         Context $context,
-        AssetRepository $assetRepository,
         AssetCollection $assetCollection,
         Config $config,
         array $data = []
     ) {
         if ($config->isHintEnabled()) {
-            $this->assetRepository = $assetRepository;
+            $this->assetRepository = $context->getAssetRepository();
             $this->assetCollection = $assetCollection;
             $this->addAssets();
         }


### PR DESCRIPTION
Checked on Magento 2.0.7.
Asset repository object already exists in context object so incorrect dependency has been removed.
